### PR TITLE
Improve speed of object lookups in pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,13 @@ return inaccurate results.
 
 `update()` will changes both the value in the RangeIndex table and the object's value.
 
-Update is very fast in SQLite, but slower in Pandas since object lookup is O(n) there.
+Update is fast, it's O(log n) in both sqlite and pandas.
 
 ### remove()
 
 `remove(self, obj: Any)` removes an object. 
 
-Remove is very fast in SQLite, but slower in Pandas since object lookup is O(n) there. Pandas also needs to rebuild
-some data structures when an object is removed.
+Remove is fast in SQLite but slower in Pandas. This is because removing an item requires rebuilding arrays there.
 
 ### Container methods
 

--- a/perf/pd_sortedsearch.ipynb
+++ b/perf/pd_sortedsearch.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "efb3d265",
+   "metadata": {},
+   "source": [
+    "seeing a weird result where doing a sortedsearch is slower than a full scan on 1M items\n",
+    "\n",
+    "replicate and debug"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "79469748",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import time\n",
+    "import pandas as pd\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e87c7121",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ids</th>\n",
+       "      <th>x</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>10224</th>\n",
+       "      <td>21497</td>\n",
+       "      <td>0.246577</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13066</th>\n",
+       "      <td>27557</td>\n",
+       "      <td>0.023987</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14169</th>\n",
+       "      <td>29835</td>\n",
+       "      <td>0.172047</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16056</th>\n",
+       "      <td>33902</td>\n",
+       "      <td>0.222844</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>103985</th>\n",
+       "      <td>43325</td>\n",
+       "      <td>0.256925</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>28201</th>\n",
+       "      <td>59260</td>\n",
+       "      <td>0.237232</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>34970</th>\n",
+       "      <td>73590</td>\n",
+       "      <td>0.154951</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45616</th>\n",
+       "      <td>95913</td>\n",
+       "      <td>0.607471</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          ids         x\n",
+       "10224   21497  0.246577\n",
+       "13066   27557  0.023987\n",
+       "14169   29835  0.172047\n",
+       "16056   33902  0.222844\n",
+       "103985  43325  0.256925\n",
+       "28201   59260  0.237232\n",
+       "34970   73590  0.154951\n",
+       "45616   95913  0.607471"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ids = list(set(random.choice(range(9999999999)) for _ in range(10**6)))\n",
+    "xs = [random.random() for _ in range(len(ids))]\n",
+    "\n",
+    "df = pd.DataFrame({'ids': ids, 'x': xs})\n",
+    "df.sort_values('ids', inplace=True)\n",
+    "df.head(n=8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "71f468c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.12146663665771484\n",
+      "5436896889.0\n",
+      "5436896889\n"
+     ]
+    }
+   ],
+   "source": [
+    "t0 = time.time()\n",
+    "for _ in range(1000):\n",
+    "    rand_id = random.choice(ids)\n",
+    "    r = df.iloc[df['ids'].searchsorted(rand_id)]\n",
+    "t1 = time.time()\n",
+    "print(t1-t0)\n",
+    "print(r['ids'])\n",
+    "print(rand_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "c263129d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.9073905944824219\n",
+      "[4044968394]\n",
+      "4044968394\n"
+     ]
+    }
+   ],
+   "source": [
+    "t0 = time.time()\n",
+    "for _ in range(1000):\n",
+    "    rand_id = random.choice(ids)\n",
+    "    r = df[df['ids'] == rand_id] \n",
+    "t1 = time.time()\n",
+    "print(t1-t0)\n",
+    "print(r['ids'].values)\n",
+    "print(rand_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "a4c0c216",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame({'ids': [], 'x': []})\n",
+    "df['ids'].searchsorted(rand_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "58d60ea0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(df['ids'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3766a549",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/perf/pd_sortedsearch.ipynb
+++ b/perf/pd_sortedsearch.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "efb3d265",
+   "id": "c1ce7f62",
    "metadata": {},
    "source": [
     "seeing a weird result where doing a sortedsearch is slower than a full scan on 1M items\n",
@@ -12,8 +12,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "79469748",
+   "execution_count": 1,
+   "id": "4adf3581",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,8 +24,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "e87c7121",
+   "execution_count": 2,
+   "id": "2c28cd24",
    "metadata": {},
    "outputs": [
     {
@@ -55,62 +55,62 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>10224</th>\n",
-       "      <td>21497</td>\n",
-       "      <td>0.246577</td>\n",
+       "      <th>1540</th>\n",
+       "      <td>3277</td>\n",
+       "      <td>0.437723</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>13066</th>\n",
-       "      <td>27557</td>\n",
-       "      <td>0.023987</td>\n",
+       "      <th>2778</th>\n",
+       "      <td>5880</td>\n",
+       "      <td>0.653906</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>14169</th>\n",
-       "      <td>29835</td>\n",
-       "      <td>0.172047</td>\n",
+       "      <th>3807</th>\n",
+       "      <td>7992</td>\n",
+       "      <td>0.056061</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>16056</th>\n",
-       "      <td>33902</td>\n",
-       "      <td>0.222844</td>\n",
+       "      <th>11820</th>\n",
+       "      <td>24792</td>\n",
+       "      <td>0.698452</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>103985</th>\n",
-       "      <td>43325</td>\n",
-       "      <td>0.256925</td>\n",
+       "      <th>16480</th>\n",
+       "      <td>34521</td>\n",
+       "      <td>0.572589</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>28201</th>\n",
-       "      <td>59260</td>\n",
-       "      <td>0.237232</td>\n",
+       "      <th>23965</th>\n",
+       "      <td>50072</td>\n",
+       "      <td>0.395231</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>34970</th>\n",
-       "      <td>73590</td>\n",
-       "      <td>0.154951</td>\n",
+       "      <th>26307</th>\n",
+       "      <td>54781</td>\n",
+       "      <td>0.052122</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>45616</th>\n",
-       "      <td>95913</td>\n",
-       "      <td>0.607471</td>\n",
+       "      <th>31475</th>\n",
+       "      <td>65709</td>\n",
+       "      <td>0.093516</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "          ids         x\n",
-       "10224   21497  0.246577\n",
-       "13066   27557  0.023987\n",
-       "14169   29835  0.172047\n",
-       "16056   33902  0.222844\n",
-       "103985  43325  0.256925\n",
-       "28201   59260  0.237232\n",
-       "34970   73590  0.154951\n",
-       "45616   95913  0.607471"
+       "         ids         x\n",
+       "1540    3277  0.437723\n",
+       "2778    5880  0.653906\n",
+       "3807    7992  0.056061\n",
+       "11820  24792  0.698452\n",
+       "16480  34521  0.572589\n",
+       "23965  50072  0.395231\n",
+       "26307  54781  0.052122\n",
+       "31475  65709  0.093516"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "71f468c2",
+   "id": "1681e2ed",
    "metadata": {},
    "outputs": [
     {
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "c263129d",
+   "id": "95980b3b",
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "a4c0c216",
+   "id": "e1103f56",
    "metadata": {},
    "outputs": [
     {
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "58d60ea0",
+   "id": "e90cac80",
    "metadata": {},
    "outputs": [
     {
@@ -223,8 +223,251 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 51,
+   "id": "8b2a194d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "792814"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pos = df['ids'].searchsorted(rand_id)\n",
+    "df.iloc[pos].name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e0a2873e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3312123877\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "3312123877"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rand_id = random.choice(ids)\n",
+    "s = df['ids']\n",
+    "pos = s.searchsorted(rand_id)\n",
+    "print(rand_id)\n",
+    "s.values[pos]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b04972ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1540      3277\n",
+       "2778      5880\n",
+       "3807      7992\n",
+       "11820    24792\n",
+       "16480    34521\n",
+       "Name: ids, dtype: int64"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ca9cf92a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ids</th>\n",
+       "      <th>x</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1540</th>\n",
+       "      <td>3277</td>\n",
+       "      <td>0.437723</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2778</th>\n",
+       "      <td>5880</td>\n",
+       "      <td>0.653906</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3807</th>\n",
+       "      <td>7992</td>\n",
+       "      <td>0.056061</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11820</th>\n",
+       "      <td>24792</td>\n",
+       "      <td>0.698452</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16480</th>\n",
+       "      <td>34521</td>\n",
+       "      <td>0.572589</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         ids         x\n",
+       "1540    3277  0.437723\n",
+       "2778    5880  0.653906\n",
+       "3807    7992  0.056061\n",
+       "11820  24792  0.698452\n",
+       "16480  34521  0.572589"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "00ded5e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s.searchsorted(7992)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c1f801a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3185573894"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ef70049c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3185573894"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s.at[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "9b548cda",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7992"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s.values[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "id": "3766a549",
+   "id": "4d9d2856",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/perf/sqlite.ipynb
+++ b/perf/sqlite.ipynb
@@ -70,17 +70,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "things = [make_thing() for _ in range(10**6)]\n",
-    "ri = RangeIndex(things, on={'x': int, 'y': float}, engine='pandas')\n"
+    "things = [make_thing() for _ in range(10**7)]\n",
+    "ri = RangeIndex(things, on={'x': int, 'y': float}, engine='sqlite')\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "f73cbc61",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.166684627532959e-05\n",
+      "Thing(x=100, y=0.5518599477492581, desc='zdtxl')\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_updates = 10**3\n",
+    "random.shuffle(things)\n",
+    "t0 = time.time()\n",
+    "for t in things[:n_updates]:\n",
+    "    ri.update(t, {'x':100})\n",
+    "t1 = time.time()\n",
+    "print((t1-t0)/n_updates)\n",
+    "print(things[0])"
+   ]
   },
   {
    "cell_type": "code",
@@ -100,12 +118,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "85e59fee",
    "metadata": {},
    "outputs": [],
    "source": [
-    "n=10**6\n",
+    "n=10**7\n",
     "find_times = {}\n",
     "filter_times = {}\n",
     "n_runs = 10\n",
@@ -121,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "870b7db9",
    "metadata": {},
    "outputs": [
@@ -129,21 +147,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 0.005s\n",
-      "10 0.005s\n",
-      "100 0.004s\n",
-      "1000 0.005s\n",
-      "10000 0.006s\n",
-      "100000 0.015s\n",
-      "1000000 0.048s\n"
+      "1 0.002s\n",
+      "10 0.085ms\n",
+      "100 0.291ms\n",
+      "1000 0.002s\n",
+      "10000 0.019s\n",
+      "100000 0.227s\n",
+      "1000000 1.765s\n"
      ]
     }
    ],
    "source": [
     "def to_str(t: float):\n",
-    "    if t < 10**-6:\n",
+    "    if t < 10**-4:\n",
     "        return \"{}μs\".format(round(t*10**6,3))\n",
-    "    elif t < 10**-3:\n",
+    "    elif t < 10**-1:\n",
     "        return \"{}ms\".format(round(t*10**3, 3))\n",
     "    else:\n",
     "        return \"{}s\".format(round(t, 3))\n",
@@ -155,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "7e523b8a",
    "metadata": {},
    "outputs": [
@@ -165,7 +183,7 @@
        "1.0"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "37a29a04",
    "metadata": {},
    "outputs": [
@@ -184,7 +202,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.053186893463134766\n"
+      "1.7757248878479004\n"
      ]
     }
    ],
@@ -197,17 +215,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "d33fa5f7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1.0"
+       "0.99"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,17 +236,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "74d6f4ae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[0, 3, 1, 4, 0, 0, 0, 1, 3, 0]"
+       "[8, 3, 0, 9, 6, 0, 9, 3, 6, 9]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -239,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "7ad7659a",
    "metadata": {},
    "outputs": [
@@ -249,7 +267,7 @@
        "1.0"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -260,27 +278,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "82136eee",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "203.87075448036194\n",
-      "Thing(x=100, y=0.5576326105432597, desc='jdujg')\n"
-     ]
-    }
-   ],
-   "source": [
-    "t0 = time.time()\n",
-    "for t in things[-10**5:]:\n",
-    "    ri.update(t, {'x':100})\n",
-    "t1 = time.time()\n",
-    "print(t1-t0)\n",
-    "print(things[-1])"
-   ]
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -305,18 +307,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "642443ba",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.1135807037353517e-05 999900\n"
+     ]
+    }
+   ],
    "source": [
     "ri.add_many(things)\n",
+    "n_rm = 10**2\n",
     "t0 = time.time()\n",
-    "for t in things[-10**5:]:\n",
+    "for t in things[:n_rm]:\n",
     "    ri.remove(t)\n",
     "t1 = time.time()\n",
-    "print(t1-t0, len(ri))"
+    "print((t1-t0)/n_rm, len(ri))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0e5469c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/perf/sqlite.ipynb
+++ b/perf/sqlite.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "things = [make_thing() for _ in range(10**6)]\n",
-    "ri = RangeIndex(things, on={'x': int, 'y': float})\n"
+    "ri = RangeIndex(things, on={'x': int, 'y': float}, engine='pandas')\n"
    ]
   },
   {
@@ -129,13 +129,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 0.118ms\n",
-      "10 0.074ms\n",
-      "100 0.28ms\n",
-      "1000 0.002s\n",
-      "10000 0.02s\n",
-      "100000 0.23s\n",
-      "1000000 1.743s\n"
+      "1 0.005s\n",
+      "10 0.005s\n",
+      "100 0.004s\n",
+      "1000 0.005s\n",
+      "10000 0.006s\n",
+      "100000 0.015s\n",
+      "1000000 0.048s\n"
      ]
     }
    ],
@@ -184,7 +184,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.7975380420684814\n"
+      "0.053186893463134766\n"
      ]
     }
    ],
@@ -225,7 +225,7 @@
     {
      "data": {
       "text/plain": [
-       "[9, 0, 0, 1, 4, 0, 3, 9, 4, 2]"
+       "[0, 3, 1, 4, 0, 0, 0, 1, 3, 0]"
       ]
      },
      "execution_count": 8,
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "82136eee",
    "metadata": {},
    "outputs": [
@@ -268,8 +268,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.7316780090332031\n",
-      "Thing(x=100, y=0.009954450038617169, desc='ffzwr')\n"
+      "203.87075448036194\n",
+      "Thing(x=100, y=0.5576326105432597, desc='jdujg')\n"
      ]
     }
    ],
@@ -305,18 +305,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "642443ba",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.8973889350891113 900000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ri.add_many(things)\n",
     "t0 = time.time()\n",
@@ -325,14 +317,6 @@
     "t1 = time.time()\n",
     "print(t1-t0, len(ri))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9be192da",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/rangeindex/idx_pandas.py
+++ b/rangeindex/idx_pandas.py
@@ -1,5 +1,6 @@
 from typing import *
 
+import numpy as np
 import pandas as pd
 
 from rangeindex.constants import *
@@ -33,6 +34,7 @@ class PandasIndex:
         new_df[PYOBJ_ID_COL] = [ptr]
         new_df[PYOBJ_COL] = [obj]
         self.df = pd.concat([self.df, new_df])
+        self.df.sort_values(PYOBJ_ID_COL, inplace=True)
 
     def add_many(self, objs: List[Any]):
         """Add a collection of objects to the index."""
@@ -55,9 +57,10 @@ class PandasIndex:
                 for field, dtype in self.fields.items()
             }
         )
-        new_df[PYOBJ_ID_COL] = list(new_objs.keys())
+        new_df[PYOBJ_ID_COL] = np.array(list(new_objs.keys()), dtype='uint64')
         new_df[PYOBJ_COL] = list(new_objs.values())
         self.df = pd.concat([self.df, new_df])
+        self.df.sort_values(PYOBJ_ID_COL, inplace=True)
 
     def find(self, where: Optional[str] = None) -> List:
         """Find Python objects that match the query constraints."""
@@ -66,24 +69,45 @@ class PandasIndex:
         return self.df.query(where)[PYOBJ_COL].to_list()
 
     def remove(self, obj: Any):
-        """Remove a single object from the index. Slow operation (requires table scan + rebuilding parts of table)."""
-        i = self.df[self.df[PYOBJ_ID_COL] == id(obj)].index[0]
-        self.df.drop(i, inplace=True)
+        """Remove a single object from the index. Slow operation (requires rebuilding parts of table)."""
+        ptr = id(obj)
+        i = self._find_idx(ptr)
+        if i == -1:
+            raise KeyError(f'Could not find object with id: {ptr}')
+        else:
+            self.df.drop(index=self.df.index[i], inplace=True)
 
     def update(self, obj: Any, updates: Dict[str, Any]):
-        """Update a single object in the index. Somewhat slow operation (requires table scan)."""
-        i = self.df[self.df[PYOBJ_ID_COL] == id(obj)].index[0]
-        for field, new_value in updates.items():
-            if field in self.fields:
-                self.df.at[i, field] = new_value
-            # apply changes to the obj as well
-            setattr(obj, field, new_value)
+        """Update a single object in the index. Fast - it's O(log(n)) since table is sorted by object id."""
+        ptr = id(obj)
+        i = self._find_idx(ptr)
+        if i == -1:
+            raise KeyError(f'Could not find object with id: {ptr}')
+        else:
+            for field, new_value in updates.items():
+                if field in self.fields:
+                    field_loc = self.df.columns.get_loc(field)
+                    self.df.iloc[i, field_loc] = new_value
+                # apply changes to the obj as well
+                setattr(obj, field, new_value)
+
+    def _find_idx(self, ptr: int) -> int:
+        """
+        Look up a pointer in {PYOBJ_ID_COL} and returns its numeric position ("iloc" in pandas terms).
+
+        Returns -1 if not found.
+        """
+        i = self.df[PYOBJ_ID_COL].searchsorted(ptr)
+        pyobj_col_loc = self.df.columns.get_loc(PYOBJ_ID_COL)
+        if self.df.iloc[i, pyobj_col_loc] == ptr:
+            return i
+        return -1
 
     def __len__(self) -> int:
         return len(self.df)
 
     def __contains__(self, obj) -> bool:
-        return id(obj) in self.df[PYOBJ_ID_COL]
+        return self._find_idx(id(obj)) != -1
 
     def __iter__(self):
         return iter(self.df[PYOBJ_COL])

--- a/rangeindex/idx_pandas.py
+++ b/rangeindex/idx_pandas.py
@@ -98,6 +98,9 @@ class PandasIndex:
         Returns -1 if not found.
         """
         i = self.df[PYOBJ_ID_COL].searchsorted(ptr)
+        if i == len(self.df):
+            # happens when df is empty, or the ptr is bigger than any obj ptr we have
+            return -1
         pyobj_col_loc = self.df.columns.get_loc(PYOBJ_ID_COL)
         if self.df.iloc[i, pyobj_col_loc] == ptr:
             return i

--- a/test/test_edge_cases.py
+++ b/test/test_edge_cases.py
@@ -111,3 +111,12 @@ def test_remove_many(engine):
     assert all([t not in ri for t in things[:5]])
     print('expected:', sorted([id(t) for t in things[5:]]))
     assert all([t in ri for t in things[5:]])
+
+
+def test_empty(engine):
+    ri = RangeIndex(on={'x': int})
+    assert ri not in ri
+    assert not ri.find('x == 3')
+    for _ in ri:
+        # should be empty, won't reach here
+        assert False

--- a/test/test_edge_cases.py
+++ b/test/test_edge_cases.py
@@ -91,3 +91,23 @@ def test_add_many_with_duplicates(engine):
 def test_find_on_empty_idx(engine):
     ri = RangeIndex(on={"x": float}, engine=engine)
     assert len(ri.find("x != x")) == 0
+
+
+def test_update_many(engine):
+    things = [Thing(x=1) for _ in range(10)]
+    ri = RangeIndex(things, on={"x": int}, engine=engine)
+    for i in range(5):
+        ri.update(things[i], {'x': 2})
+    assert len(ri.find("x == 1")) == 5
+    assert len(ri.find("x == 2")) == 5
+
+
+def test_remove_many(engine):
+    things = [Thing(x=1) for _ in range(10)]
+    ri = RangeIndex(things, on={"x": int}, engine=engine)
+    for i in range(5):
+        ri.remove(things[i])
+    assert len(ri) == 5
+    assert all([t not in ri for t in things[:5]])
+    print('expected:', sorted([id(t) for t in things[5:]]))
+    assert all([t in ri for t in things[5:]])


### PR DESCRIPTION
Sorting the pandas dataframe by object id makes `__contains__` and `update` operations much faster, O(log(n)) instead of O(n).

This change made `update` 10x faster  in a 1M-row dataset.